### PR TITLE
Replace soon-to-be-deprecated user function with current equivalent

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -373,8 +373,7 @@ function edd_wl_remove_item_url( $cart_key, $post, $ajax = false ) {
 */
 function edd_wl_get_query( $status = array( 'publish', 'private' ) ) {
 
-	global $current_user;
-	get_currentuserinfo();
+	$current_user = wp_get_current_user();
 
 	if ( 'public' == $status ) {
 		$status = 'publish';


### PR DESCRIPTION
`get currentuserinfo()` will be deprecated soon. Use `wp_get_current_user()` instead.

closes #42 